### PR TITLE
Rename to "Module Declarations" and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,13 @@ Module declarations lift this restriction: they can be imported statically if th
 
 We are developing these two features as separate proposals because module declarations present additional complexity around static import statements that module expressions don't need, and module expressions have their own [motivations](https://github.com/tc39/proposal-module-expressions#problem-space) independent from module declarations. Module declarations inherit different design decisions from module expressions, so the advancement of this proposal in its current shape depends on the evolution of module expressions.
 
+<!--
+
 ### Does this proposal work with import maps?
 
 [Import maps](https://github.com/WICG/import-maps) can be used in conjunction with module declarations, in that the import map can redirect bare specifiers to be found in module declarations, rather than independent fetches. Mechanically: The lookup in the import map (which is done as part of "resolving a module specifier") precedes the interpretation of declarations in the module specifier (which are treated as part of the module map key). (TODO: add example of use together.)
+
+-->
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# JavaScript Module Fragments
+# JavaScript Module Declarations
 
-Champion: Daniel Ehrenberg (Igalia, in partnership with [eyeo](https://eyeo.com/))
+Champions: Daniel Ehrenberg, Nicolò Ribaudo
 
 Stage 1
 
-JavaScript module fragments are a syntax for named, inline JS modules, which can be used for bundling multiple modules into a single JavaScript file.
+JavaScript module declarations are a syntax for named, inline JS modules, which can be used for bundling multiple modules into a single JavaScript file.
 
 ## Motivation
 
@@ -20,7 +20,7 @@ This proposal adds a syntax to JavaScript to allow for several JavaScript module
 
 ```js
 // filename: app.js
-module countBlock {
+module countModule {
   let i = 0;
 
   export function count() {
@@ -29,60 +29,62 @@ module countBlock {
   }
 }
 
-export module uppercaseBlock {
+export module uppercaseModule {
   export function uppercase(string) {
     return string.toUpperCase();
   }
 }
 
-import { count } from countBlock;
-import { uppercase } from uppercaseBlock;
+import { count } from countModule;
+import { uppercase } from uppercaseModule;
 
 console.log(count()); // 1
 console.log(uppercase("daniel")); // "DANIEL"
 ```
 
-This module, containing multiple module fragments, is referenced from an HTML file via a script tag:
+This module, containing multiple module declarations, is referenced from an HTML file via a script tag:
 
 ```html
 <script type=module src="./app.js"></script>
 ```
 
-Module fragments, if exported, can also be used outside of the file where they are defined.
+Module declarations, if exported, can also be used outside of the file where they are defined.
 
 ```html
 <script type=module>
-  import { uppercaseBlock } from "./app.js";
-  import { uppercase } from uppercaseBlock;
+  import { uppercaseModule } from "./app.js";
+  import { uppercase } from uppercaseModule;
   console.log(uppercase("yes")); // "YES"
 </script>
 ```
 
-The `countBlock` module, on the other hand, is not exported, and can not be used this way.
+The `countModule` module, on the other hand, is not exported, and can not be used this way.
 
 ## Syntax
 
-`ModuleFragment` is a new nonterminal which can exist at the top level of a module, like `import` and `export` statements. Note that, as in the case of module blocks, there is no shared lexical scope between module fragments and the module that contains each other; they are simply side by side, like modules fetched from different URLs.
+`ModuleDeclaration` is a new nonterminal which can exist at the top level of a module, like `import` and `export` statements, or of a script. Note that, as in the case of [module expressions](https://github.com/tc39/proposal-module-expressions), there is no shared lexical scope between module declarations and the module that contains each other; they are simply side by side, like modules fetched from different URLs.
 
 ```
-Statement[Yield, Await, Return] :
+ModuleItem[Yield, Await, Return] :
     ...
-    <ins>ModuleFragment</ins>
+    <ins>ModuleDeclaration</ins>
 
-ModuleFragment : module [no LineTerminator here] Identifier { Module }
+ScriptItem[Yield, Await, Return] :
+    ...
+    <ins>ModuleDeclaration</ins>
+
+ModuleDeclaration : module [no LineTerminator here] Identifier { ModuleBody? }
 ```
 
-Module fragments may be nested inside of other module fragments and can appear anywhere a statement can.
-Host environments may limit the kinds of module specifiers permitted, or where module fragments are used at all. See [HTML integration](#html-integration) below for an example.
+Module declarations may be nested inside of other module declarations.
 
 ## Semantics
 
-- A module fragment at the top-level of a module can be imported statically.
-- A module fragment not at the top-level is syntactic sugar for a [JS module block](https://github.com/tc39/proposal-js-module-blocks) (which also uses the `module` contextual keyword, but without a module specifier).
-- Module fragments are only available outside of the module they are contained in if they are exported explicitly.
-- Each module fragment has its own top-level lexical scope. There is no shared scope.
+- Module declarations can be imported statically.
+- Module declarations are only available outside of the module they are contained in if they are exported explicitly.
+- Each module declaration has its own top-level lexical scope. There is no shared scope.
 
-Within a particular Realm (e.g., HTML document), if a module fragment is imported multiple times, the same module "instance" is returned, just like with modules declared in separate JS files. In other words, module fragments are singletons.
+If a module declaration is imported multiple times, the same module "instance" is returned, just like with modules declared in separate JS files. In other words, module declarations are singletons.
 
 ## HTML integration
 
@@ -90,21 +92,19 @@ Note: The following is framed to give details for HTML/the Web platform, but oth
 
 ### `import.meta.url`
 
-The `import.meta.url` inside a module fragment is the module specifier of the surrounding module. For example,
+The `import.meta.url` inside a module declaration is the module specifier of the surrounding module. For example,
 
 ```js
 // https://example.com/xyz.js
-module fragment { console.log(import.meta.url); }
-import fragment;
+module mod { console.log(import.meta.url); }
+import mod;
 ```
 
 The above code will log `https://example.com/xyz.js`.
 
-Relative module specifiers within a module fragment are resolved just as if they were defined in the outer module. This behavior is the same as if they were calculated by `new URL(moduleSpecifier, import.meta.url)`.
+Relative module specifiers within a module declaration are resolved just as if they were defined in the outer module. This behavior is the same as if they were calculated by `new URL(moduleSpecifier, import.meta.url)`.
 
-### Module map semantics
-
-JS module fragments, like all other modules, are kept track of in the [module map](https://html.spec.whatwg.org/#module-map). Whenever a JavaScript module which contains module fragments is imported (whether or not the fragment was imported), there is a module map entry made for each module fragment. The module fragments (as well as the top-level module) only have their dependencies loaded if they are *directly* imported; other entries may exist as a side effect, since they were found in the same file, but it's not time to fetch and parse their dependencies until that particular module is imported. This means that modules in the module map will need an extra bit to track whether they are "loaded" in this sense.
+This behavior follows from the semantics proposed for [module expressions](https://github.com/tc39/proposal-module-expressions).
 
 ## FAQ
 
@@ -112,44 +112,38 @@ JS module fragments, like all other modules, are kept track of in the [module ma
 
 Brave has [expressed concerns](https://brave.com/webbundles-harmful-to-content-blocking-security-tools-and-the-open-web/) about the possibility that bundling could be used to let servers remap URLs more easily, which cuts against privacy techniques for blocking tracking, etc. This proposal has significantly less expressivity than Web Bundles, making these issues not as big of a risk:
 
-JS module bundles are restricted to just same-origin JS, so they are analogous in scope to what is currently done with popular bundlers like webpack and rollup, not adding more power. Although it is possible to rotate/scramble fragment identifiers, it is reasonable to treat the whole outer module containing several module fragments as a unit, with content blockers targeting either all or none of it.
+JS module bundles are restricted to just same-origin JS, so they are analogous in scope to what is currently done with popular bundlers like webpack and rollup, not adding more power. Although it is possible to rotate/scramble declaration identifiers, it is reasonable to treat the whole outer module containing several module declarations as a unit, with content blockers targeting either all or none of it.
 
-Martin Thompson of Mozilla has articulated a preference for bundling schemes to be based on URLs which accurately identify the identity of the resource. As module fragments can not be loaded directly, but only through the outer module, and the outer module is fetched by its URL, the identity is clearly represented. (TODO: confirm this with MT)
+Martin Thompson of Mozilla has articulated a preference for bundling schemes to be based on URLs which accurately identify the identity of the resource. As module declarations can not be loaded directly, but only through the outer module, and the outer module is fetched by its URL, the identity is clearly represented. (TODO: confirm this with MT)
 
-### Why have module fragments, rather than just focusing on general-purpose resource bundles?
+### Why have module declarations, rather than just focusing on general-purpose resource bundles?
 
-JS module fragments provide a very limited subset of the functionality of [resource bundle loading](https://github.com/littledan/resource-bundles/blob/main/subresource-loading.md) behavior.
+Module declarations provide a very limited subset of the functionality of [resource bundle loading](https://github.com/littledan/resource-bundles/blob/main/subresource-loading.md) behavior.
 
-As a point-by-point comparison to how resource bundles and module fragments compare:
-- **Level**: Resource bundle loading causes new assets to be available at the "fetch"/network level, engaging larger amounts of the browser. By contrast, JS module fragments are contained to the module loading mechanism, in a more limited scope.
-- **Types**: JS module fragments can only contain JavaScript, but resource bundles can contain resources of any MIME type.
-- **Metadata**: Resource bundles can even support other headers alongside Content-Type for more information about individual responses, whereas JS module fragments have no syntax for any of this metadata.
+As a point-by-point comparison to how resource bundles and module declarations compare:
+- **Level**: Resource bundle loading causes new assets to be available at the "fetch"/network level, engaging larger amounts of the browser. By contrast, module declarations are contained to the module loading mechanism, in a more limited scope.
+- **Types**: Module declarations can only contain JavaScript, but resource bundles can contain resources of any MIME type.
+- **Metadata**: Resource bundles can even support other headers alongside Content-Type for more information about individual responses, whereas module declarations have no syntax for any of this metadata.
 - **Security/privacy considerations**: Because JS module bundles only affect how JavaScript is loaded, and do things equivalent to what bundlers do today, there's little additional security/privacy surface to worry about. By contrast, the story is more complicated with resource bundles.
-- **HTTP caching**: JS module fragments are cached together in the HTTP cache with the enclosing module. There is no way for the browser to request just the fragments it is missing. By contrast, [resource bundle loading](https://github.com/littledan/resource-bundles/blob/main/subresource-loading.md) divides resources into chunks, and only the chunks which are not present in cache are loaded.
-- **Versioning/cache busting**: Resource bundle loading allows chunk IDs to be rotated to cause some resources to be reloaded, even if they are present in cache, removing the need to change the URL. By contrast, JS module fragments do not provide such a mechanism, so a solution at some other level is needed.
-- **Parsing performance**: Resource bundles are a breeze to parse because of their binary format which is clearly layered apart from their payloads, and an attention to detail to support both streaming and random-access efficiently. JS module fragments, instead, require parsing the whole JS file linearly, and do not support random access (and streaming is only possible if we weaken early error semantics).
-- **Per-asset overhead**: Because resource bundle loading takes place at a more broad level in the browser, there are more codepaths that each resource hints (e.g., renderer-internal data structures, content blocking, etc). This makes them more difficult to optimize. By contrast, JS module fragments go through more specific code paths, so they may be easier to optimize for per-asset overhead.
-- **Complexity**: Module fragments are a very simple mechanism. Tools and engines which know how to read and write JavaScript can be incrementally updated to support them. Resource bundles are a heavier lift, but bring certain benefits in exchange for that.
+- **HTTP caching**: Module declarations are cached together in the HTTP cache with the enclosing module. There is no way for the browser to request just the declarations it is missing. By contrast, [resource bundle loading](https://github.com/littledan/resource-bundles/blob/main/subresource-loading.md) divides resources into chunks, and only the chunks which are not present in cache are loaded.
+- **Versioning/cache busting**: Resource bundle loading allows chunk IDs to be rotated to cause some resources to be reloaded, even if they are present in cache, removing the need to change the URL. By contrast, module declarations do not provide such a mechanism, so a solution at some other level is needed.
+- **Parsing performance**: Resource bundles are a breeze to parse because of their binary format which is clearly layered apart from their payloads, and an attention to detail to support both streaming and random-access efficiently. Module declarations, instead, require parsing the whole JS file linearly, and do not support random access (and streaming is only possible if we weaken early error semantics).
+- **Per-asset overhead**: Because resource bundle loading takes place at a more broad level in the browser, there are more codepaths that each resource hints (e.g., renderer-internal data structures, content blocking, etc). This makes them more difficult to optimize. By contrast, module declarations go through more specific code paths, so they may be easier to optimize for per-asset overhead.
+- **Complexity**: Module declarations are a very simple mechanism. Tools and engines which know how to read and write JavaScript can be incrementally updated to support them. Resource bundles are a heavier lift, but bring certain benefits in exchange for that.
 
-It's my (Dan Ehrenberg's) hypothesis at this point that, for best performance, JS module fragments should be *nested inside* resource bundles. This way, the expressiveness of resource bundles can be combined with the low per-asset overhead of JS module fragments: most of the "blow-up" in terms of the number of assets today is JS modules, so it makes sense to have a specialized solution for that case, which can be contained inside the JS engine. The plan from here will be to develop prototype implementations (both in browsers and build tools) to validate this hypothesis before shipping.
+It's my (Dan Ehrenberg's) hypothesis at this point that, for best performance, module declarations should be *nested inside* resource bundles. This way, the expressiveness of resource bundles can be combined with the low per-asset overhead of module declarations: most of the "blow-up" in terms of the number of assets today is JS modules, so it makes sense to have a specialized solution for that case, which can be contained inside the JS engine. The plan from here will be to develop prototype implementations (both in browsers and build tools) to validate this hypothesis before shipping.
 
-### Why have this proposal and module blocks as two separate things, rather than one common language feature?
+### Why have this proposal and module expressions as two separate things, rather than one common language feature?
 
-[JS module blocks](https://github.com/tc39/proposal-js-module-blocks) are a separate concept for a module syntax which acts like a specifier: it can be imported with `import()` or `new Worker()`, but not with a static import statement, as it is not in the module map. Instead, it is a *key* in the module map. JS module blocks may be imported in other Realms.
+The [module expressions](https://github.com/tc39/proposal-module-expressions) proposal introduces the expressions form of inline modules. Being expressions, they are inherently dynamic: they can be imported with `import()` or `new Worker()`, but not with static import statements.
 
-Module fragments lift this restriction: they can be imported statically if they appear at the top level of a module. This makes module fragments more useful for bundling than module blocks. See more context in [this FAQ](https://github.com/tc39/proposal-js-module-blocks#can-module-blocks-help-with-bundling).
+Module declarations lift this restriction: they can be imported statically if they appear at the top level of a module. This makes module declarations more useful for bundling than module expressions. See more context in [this FAQ](https://github.com/tc39/proposal-module-expressions#can-module-blocks-help-with-bundling).
 
-If module fragments appear somewhere else (within an `eval`, in a legacy script, in an inline module, nested inside of a function, …), they act similar to a module block that is assigned to a variable:
-
-```js
-const mod = module { ... };
-module mod { ... }
-new Worker(mod);
-```
+We are developing these two features as separate proposals because module declarations present additional complexity around static import statements that module expressions don't need, and module expressions have their own [motivations](https://github.com/tc39/proposal-module-expressions#problem-space) independent from module declarations. Module declarations inherit different design decisions from module expressions, so the advancement of this proposal in its current shape depends on the evolution of module expressions.
 
 ### Does this proposal work with import maps?
 
-[Import maps](https://github.com/WICG/import-maps) can be used in conjunction with module fragments, in that the import map can redirect bare specifiers to be found in module fragments, rather than independent fetches. Mechanically: The lookup in the import map (which is done as part of "resolving a module specifier") precedes the interpretation of fragments in the module specifier (which are treated as part of the module map key). (TODO: add example of use together.)
+[Import maps](https://github.com/WICG/import-maps) can be used in conjunction with module declarations, in that the import map can redirect bare specifiers to be found in module declarations, rather than independent fetches. Mechanically: The lookup in the import map (which is done as part of "resolving a module specifier") precedes the interpretation of declarations in the module specifier (which are treated as part of the module map key). (TODO: add example of use together.)
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JavaScript Module Declarations
 
-Champions: Daniel Ehrenberg, Nicolò Ribaudo
+Champions: Daniel Ehrenberg ([Bloomberg](https://techatbloomberg.com/)), Nicolò Ribaudo (Igalia, in parternship with [eyeo](https://eyeo.com/) and [Bloomberg](https://techatbloomberg.com/))
 
 Stage 1
 


### PR DESCRIPTION
This is parallel to https://github.com/tc39/proposal-module-expressions/pull/77: the two proposals are now named "Module Expressions" and "Module Declarations", to better explain their relationship and their differences.